### PR TITLE
v3.3.3

### DIFF
--- a/live-space/.env
+++ b/live-space/.env
@@ -1,1 +1,1 @@
-VERSION=v3.3.2
+VERSION=v3.3.3

--- a/live-space/server/dns.c
+++ b/live-space/server/dns.c
@@ -119,7 +119,7 @@ void resolve_dns(const char *dns_config_path, const char *domain, char *own_prec
 
     get_naptr(dns_config_path, domain, own_precedense);
 
-    while (1) {
+    while (execute_loop) {
         if (srv_ttl <= 0) {
             error_msg(sip_man_log, "(DNS) INFO: SRV-TTL expired, performing new Request.");
             char tmp[64] = {0}; 
@@ -165,6 +165,7 @@ void resolve_dns(const char *dns_config_path, const char *domain, char *own_prec
         srv_ttl -= timer;
         a_record_ttl -= timer;
     }
+    error_msg(sip_man_log, "(DNS) INFO: Cancelation-Request detected, Loop terminated");
 }
 
 void *start_dns_thread(void* args) {

--- a/live-space/server/hmr.c
+++ b/live-space/server/hmr.c
@@ -108,7 +108,7 @@ void process_hmr(char *sip_message, ManipulationEntry hmr_entries, char *sip_man
  
 
 void process_buffer(char *sip_message, ManipulationTable *modification_table,char *sip_man_log, char *sip_hmr_log) {
-    char tmp[2048];
+    char tmp[8192];
     char tmp_err_msg[128];
     strcpy(tmp, sip_message);
     char *r_uri_end = strstr(tmp, "\r\n"); 

--- a/live-space/server/include/dns.h
+++ b/live-space/server/include/dns.h
@@ -1,5 +1,6 @@
 #ifndef DNS_H
 #define DNS_H
+#include <stdatomic.h>
 
 extern char        a_record_prio10[64];
 extern char        a_record_prio20[64];
@@ -11,6 +12,8 @@ extern char         dns_config_path[128];
 extern char         domain[128];
 extern char         own_precedense[64];
 extern char         sip_man_log[64];
+
+extern volatile atomic_int execute_loop;
 
 void *start_dns_thread(void* args); 
 

--- a/live-space/server/main.c
+++ b/live-space/server/main.c
@@ -32,7 +32,7 @@ char                domain[128];
 char                own_precedense[64];     
 int                 sockfd, connfd, sockfd_ext;
 
-int                 execute_loop = 1; 
+volatile atomic_int execute_loop = 1; 
 
 //Function-Declaration:
 ManipulationTable *load_hmr(const char *hmr_path, char *sip_man_log){ 
@@ -181,18 +181,18 @@ int main()
 {
     struct sockaddr_in  sockaddr, connaddr, sockaddr_ext;
     unsigned int        connaddr_len;
-    char                buffer[2048];
+    char                buffer[8192];
     int                 rv, rv_ext;
     struct sigaction    sa;
     int                 result;
     pthread_t           dns_thread;
+    char                tmp[2048];
 
     //Default-Values (overwritten by config-file)
     char                ip_addr_ext[16] = "127.0.0.1";
     char                ip_port_ext[6]  = "10000";
     char                ip_port_int[6]  = "5060";
     char                version[8];
-    char                tmp[2048];
     int                 mirror = 0;  
     int                 dns_mode = 0; 
 
@@ -321,7 +321,7 @@ int main()
         }
 
         //2nd-Connection
-        if (mirror == 0) {
+        if (mirror == 0 && execute_loop == 1) {
             sockfd_ext = socket(AF_INET, SOCK_STREAM, 0);
             if (sockfd_ext == -1) {
                 error_msg(sip_man_log, "(MAIN) ERROR 2ND-CON: Creating of externel Socket failed.");
@@ -397,7 +397,11 @@ int main()
         }
     }
 
-    error_msg(sip_man_log, "(MAIN) INFO: Server-Loop terminated, release manipulation-tables."); 
+    error_msg(sip_man_log, "(MAIN) INFO: Terminate DNS-thread.");
+    pthread_cancel(dns_thread);
+    error_msg(sip_man_log, "(MAIN) INFO: Cancellation-Request sent to DNS-thread, waiting for terminate.");
+    pthread_join(dns_thread, NULL);
+    error_msg(sip_man_log, "(MAIN) INFO: DNS-Thread and Server-Loop terminated, release manipulation-tables."); 
     free_manipulation_table(int_modification_table);
     free_manipulation_table(ext_modification_table); 
     free_manipulation_table(mir_modification_table);

--- a/live-space/server/main.c
+++ b/live-space/server/main.c
@@ -377,21 +377,22 @@ int main()
                 rv_ext = write(sockfd_ext, buffer, strlen(buffer));
                 snprintf(tmp, sizeof(tmp), "(MAIN) INFO: Transmitted Buffer:\n%s", buffer);
                 error_msg(sip_hmr_log, tmp);
-                memset(buffer, 0, sizeof(buffer));
+                buffer[0] = '\0';
 
                 rv_ext = read(sockfd_ext, buffer, sizeof(buffer));
                 snprintf(tmp, sizeof(tmp), "(MAIN) INFO: %i bytes of data received from external server", rv_ext);
                 error_msg(sip_man_log, tmp);
                 
                 process_buffer(buffer, ext_modification_table, sip_man_log, sip_hmr_log);
-                rv = write(connfd, buffer, sizeof(buffer));
+                rv = write(connfd, buffer, strlen(buffer));
                 snprintf(tmp, sizeof(tmp), "(MAIN) INFO: Transmitted Buffer:\n%s", buffer);
                 error_msg(sip_hmr_log, tmp); 
+                buffer[0] = '\0';
             } else if (mirror == 1) {
                 process_buffer(buffer, mir_modification_table, sip_man_log, sip_hmr_log);
                 snprintf(tmp, sizeof(tmp), "(MAIN) INFO Mirror: MIR-Modification applied:\n'%s'", buffer);
                 error_msg(sip_hmr_log, tmp); 
-                rv = write(connfd, buffer, sizeof(buffer));
+                rv = write(connfd, buffer, strlen(buffer));
             }
         }
     }

--- a/live-space/shared/config.txt
+++ b/live-space/shared/config.txt
@@ -3,7 +3,7 @@
 #Introducing new config-items without having access to the source-code will cause undefined behavior
 
 #Current Version: 
-VERSION=3.3.2
+VERSION=3.3.3
 
 #TCP/IP Config
 #External ip-address will only be used if static=1

--- a/testing-space/project/.env
+++ b/testing-space/project/.env
@@ -1,1 +1,1 @@
-VERSION=v3.3.2
+VERSION=v3.3.3

--- a/testing-space/project/server/dns.c
+++ b/testing-space/project/server/dns.c
@@ -119,7 +119,7 @@ void resolve_dns(const char *dns_config_path, const char *domain, char *own_prec
 
     get_naptr(dns_config_path, domain, own_precedense);
 
-    while (1) {
+    while (execute_loop) {
         if (srv_ttl <= 0) {
             error_msg(sip_man_log, "(DNS) INFO: SRV-TTL expired, performing new Request.");
             char tmp[64] = {0}; 
@@ -165,6 +165,7 @@ void resolve_dns(const char *dns_config_path, const char *domain, char *own_prec
         srv_ttl -= timer;
         a_record_ttl -= timer;
     }
+    error_msg(sip_man_log, "(DNS) INFO: Cancelation-Request detected, Loop terminated");
 }
 
 void *start_dns_thread(void* args) {

--- a/testing-space/project/server/hmr.c
+++ b/testing-space/project/server/hmr.c
@@ -108,7 +108,7 @@ void process_hmr(char *sip_message, ManipulationEntry hmr_entries, char *sip_man
  
 
 void process_buffer(char *sip_message, ManipulationTable *modification_table,char *sip_man_log, char *sip_hmr_log) {
-    char tmp[2048];
+    char tmp[8192];
     char tmp_err_msg[128];
     strcpy(tmp, sip_message);
     char *r_uri_end = strstr(tmp, "\r\n"); 

--- a/testing-space/project/server/include/dns.h
+++ b/testing-space/project/server/include/dns.h
@@ -1,5 +1,6 @@
 #ifndef DNS_H
 #define DNS_H
+#include <stdatomic.h>
 
 extern char        a_record_prio10[64];
 extern char        a_record_prio20[64];
@@ -11,6 +12,8 @@ extern char         dns_config_path[128];
 extern char         domain[128];
 extern char         own_precedense[64];
 extern char         sip_man_log[64];
+
+extern volatile atomic_int execute_loop;
 
 void *start_dns_thread(void* args); 
 

--- a/testing-space/project/server/main.c
+++ b/testing-space/project/server/main.c
@@ -377,21 +377,24 @@ int main()
                 rv_ext = write(sockfd_ext, buffer, strlen(buffer));
                 snprintf(tmp, sizeof(tmp), "(MAIN) INFO: Transmitted Buffer:\n%s", buffer);
                 error_msg(sip_hmr_log, tmp);
-                memset(buffer, 0, sizeof(buffer));
+                buffer[0] = '\0';
 
                 rv_ext = read(sockfd_ext, buffer, sizeof(buffer));
                 snprintf(tmp, sizeof(tmp), "(MAIN) INFO: %i bytes of data received from external server", rv_ext);
                 error_msg(sip_man_log, tmp);
                 
+
                 process_buffer(buffer, ext_modification_table, sip_man_log, sip_hmr_log);
-                rv = write(connfd, buffer, sizeof(buffer));
+                rv = write(connfd, buffer, strlen(buffer));
                 snprintf(tmp, sizeof(tmp), "(MAIN) INFO: Transmitted Buffer:\n%s", buffer);
                 error_msg(sip_hmr_log, tmp); 
+                buffer[0] = '\0';
+
             } else if (mirror == 1) {
                 process_buffer(buffer, mir_modification_table, sip_man_log, sip_hmr_log);
                 snprintf(tmp, sizeof(tmp), "(MAIN) INFO Mirror: MIR-Modification applied:\n'%s'", buffer);
                 error_msg(sip_hmr_log, tmp); 
-                rv = write(connfd, buffer, sizeof(buffer));
+                rv = write(connfd, buffer, strlen(buffer));
             }
         }
     }

--- a/testing-space/project/shared/config.txt
+++ b/testing-space/project/shared/config.txt
@@ -3,7 +3,7 @@
 #Introducing new config-items without having access to the source-code will cause undefined behavior
 
 #Current Version: 
-VERSION=3.3.2
+VERSION=3.3.3
 
 #TCP/IP Config
 #External ip-address will only be used if static=1

--- a/testing-space/project/shared/inc_hmr.txt
+++ b/testing-space/project/shared/inc_hmr.txt
@@ -1,6 +1,3 @@
-#OPTIONS
-User-Agent, Dennis-Test v3.3.1
-
 #TEST
 From, host:tel.t-online.de
 From, user:+4999999999

--- a/testing-space/project/shared/out_hmr.txt
+++ b/testing-space/project/shared/out_hmr.txt
@@ -32,8 +32,4 @@ Supported, 100rel,timer
 #183
 Required, 100rel
 
-#SIP/2.0 200
-X-Test, add:Manipulated
-CSeq, number:1
-
 #478


### PR DESCRIPTION
### Server-Module
- Enhance buffer-size for sip-messages up to 8192 Bytes 
- Enhance termination-process for both, server- and dns-thread (includes optimized signal-handler) 
- Bug-Fix: write-function with correct arguments for message-lenght (old: sizeof(buffer), new: strlen(buffer)